### PR TITLE
3/24 modification: archive, 404, etc)

### DIFF
--- a/wp-content/themes/enjoy_vegan_one/404.php
+++ b/wp-content/themes/enjoy_vegan_one/404.php
@@ -7,7 +7,10 @@
  * @package enjoy_vegan_one
  */
 
-get_header(); ?>
+
+get_header(); 
+?>
+
 
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main">
@@ -18,17 +21,20 @@ get_header(); ?>
 				</header><!-- .page-header -->
 
 				<div class="page-content">
-					<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try one of the links below or a search?', 'enjoy_vegan_one' ); ?></p>
+					<p><?php esc_html_e( 'It looks like nothing was found at this location. Please go back and try again.', 'enjoy_vegan_one' ); ?></p>
 
-					<?php 
+					<!--SEARCH FORMやmost used catogories, tagsの削除>
+					/* SEARCH FORM削除
 						get_search_form();
-						/*
+						/*　最近の投稿削除
 						the_widget( 'WP_Widget_Recent_Posts' );
 						*/
 					?>
 
 					<div class="widget widget_categories">
-						<h2 class="widget-title"><?php esc_html_e( 'Most Used Categories', 'enjoy_vegan_one' ); ?></h2>
+						<h2 class="widget-title"><?php 
+						/*　Most used categories　削除
+						esc_html_e( 'Most Used Categories', 'enjoy_vegan_one' ); ?></h2>
 						<ul>
 						<?php
 							wp_list_categories( array(
@@ -45,12 +51,15 @@ get_header(); ?>
 					<?php
 
 						/* translators: %1$s: smiley */
-						/*
+						/* Recent Archivesの削除
 						$archive_content = '<p>' . sprintf( esc_html__( 'Try looking in the monthly archives. %1$s', 'enjoy_vegan_one' ), convert_smilies( ':)' ) ) . '</p>';
 						the_widget( 'WP_Widget_Archives', 'dropdown=1', "after_title=</h2>$archive_content" );
 						*/
+						/*　タグクラウンドの削除
 						the_widget( 'WP_Widget_Tag_Cloud' );
+						*/
 					?>
+					-->
 
 				</div><!-- .page-content -->
 			</section><!-- .error-404 -->

--- a/wp-content/themes/enjoy_vegan_one/archive.php
+++ b/wp-content/themes/enjoy_vegan_one/archive.php
@@ -11,6 +11,7 @@ get_header(); ?>
 
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main">
+			<div class="category">
 
 		<?php
 		if ( have_posts() ) : ?>
@@ -21,6 +22,8 @@ get_header(); ?>
 					the_archive_description( '<div class="archive-description">', '</div>' );
 				?>
 			</header><!-- .page-header -->
+
+		</div>
 
 			<?php
 			/* Start the Loop */

--- a/wp-content/themes/enjoy_vegan_one/functions.php
+++ b/wp-content/themes/enjoy_vegan_one/functions.php
@@ -180,3 +180,28 @@ function pagination($pages = '', $range = 1)
 		echo "</div></div>\n";
 	}
 }
+
+/* --------------------------
+  the_archive_title 余計な文字を削除　2019/3/24
+ ------------------------- */
+
+add_filter( 'get_the_archive_title', function ($title) {
+    if (is_category()) {
+        $title = single_cat_title('',false);
+    } elseif (is_tag()) {
+        $title = single_tag_title('',false);
+	} elseif (is_tax()) {
+	    $title = single_term_title('',false);
+	} elseif (is_post_type_archive() ){
+		$title = post_type_archive_title('',false);
+	} elseif (is_date()) {
+	    $title = get_the_time('F,Y');
+	} elseif (is_search()) {
+	    $title = 'Search Result:'.esc_html( get_search_query(false) );
+	} elseif (is_404()) {
+	    $title = '404 error: Page not found';
+	} else {
+
+	}
+    return $title;
+});

--- a/wp-content/themes/enjoy_vegan_one/sidebar.php
+++ b/wp-content/themes/enjoy_vegan_one/sidebar.php
@@ -7,6 +7,7 @@
  * @package enjoy_vegan_one
  */
 
+
 if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 	return;
 }
@@ -15,3 +16,4 @@ if ( ! is_active_sidebar( 'sidebar-1' ) ) {
 <aside id="secondary" class="widget-area">
 	<?php dynamic_sidebar( 'sidebar-1' ); ?>
 </aside><!-- #secondary -->
+

--- a/wp-content/themes/enjoy_vegan_one/style.css
+++ b/wp-content/themes/enjoy_vegan_one/style.css
@@ -111,7 +111,7 @@ dfn {
 }
 
 h1 {
-	font-size: 2em;
+	font-size: 1.5em;
 	margin: 0.67em 0;
 }
 
@@ -929,8 +929,8 @@ a:hover, a:active {
 	align-content: center;
 	align-items: center;
 	width: 40%;
-	padding: 30px;
-	min-width: 400px;
+	padding: 25px 0px;
+	min-width: 350px;
 	margin: auto;
 }
 
@@ -958,7 +958,7 @@ a:hover, a:active {
 	padding-bottom: 20px;
 	line-height: 1.8em;
 	width: 45%;
-	min-width: 400px;
+	min-width: 350px;
 }
 
 /*copyright*/
@@ -967,6 +967,13 @@ a:hover, a:active {
 	background-color: #2d2d2d;
 	color: #FFFFFF;
 }
+
+/*archive*/
+
+.category {
+	width: 100%;
+}
+
 
 /*--------------------------------------------------------------
 # Accessibility

--- a/wp-content/themes/enjoy_vegan_one/template-parts/content-none.php
+++ b/wp-content/themes/enjoy_vegan_one/template-parts/content-none.php
@@ -36,15 +36,23 @@
 		<?php elseif ( is_search() ) : ?>
 
 			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'enjoy_vegan_one' ); ?></p>
+
 			<?php
+			/* Search Formはside-barに含まれているので削除
 				get_search_form();
+			*/
+			else : 
+			?>
 
-		else : ?>
+			<p><?php 
+			esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'enjoy_vegan_one' ); ?></p>
 
-			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'enjoy_vegan_one' ); ?></p>
 			<?php
+			/* Search Formはside-barに含まれているので削除
 				get_search_form();
-
-		endif; ?>
+			*/
+		endif; 
+		?>
+		
 	</div><!-- .page-content -->
 </section><!-- .no-results -->


### PR DESCRIPTION
3/24 3:00-6:00
①Footerの見た目改善
 footer SNSとdisclaimerのmin-widthを400から350に変えて右余白削除（style.css)
SNS iconがiphoneだとめっちゃちっちゃくなるので、左右の余白を小さくして対応（style.css)
②Archiveの見た目改善
Archiveのpage-titleがでかかったので、h1の文字サイズを2emから1.5emへ変更(style.css)
ArchiveのCategory:とインスタ写真を改行するために、<div class=“category”>で改行（archive.php, style.css)
page-titleの「Category:」を消したかったので、削除（function.php)
https://naoyu.net/archive-title-hook/
Searchウィジッド削除

③404エラー（ハッシュタグで探してない場合）のページの見た目改善（404.php)

④Searchで探した時のエラーページの見た目を改善(Search.php, /template-parts/content-none.php)
